### PR TITLE
[Dependencies] Update SwiftSyntax to 0.50600.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
           "branch": null,
-          "revision": "75e60475d9d8fd5bbc16a12e0eaa2cb01b0c322e",
-          "version": "0.50500.0"
+          "revision": "0b6c22b97f8e9320bca62e82cdbee601cf37ad3f",
+          "version": "0.50600.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["variable-injector"]),        
     ],
     dependencies: [
-        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50500.0")),
+        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50600.1")),
         .package(name: "swift-argument-parser", url: "https://github.com/apple/swift-argument-parser.git", .exact("1.0.0"))
     ],
     targets: [
@@ -21,7 +21,8 @@ let package = Package(
         .target(
             name: "variable-injector-core",
             dependencies: [
-                .product(name: "SwiftSyntax", package: "SwiftSyntax"), 
+                .product(name: "SwiftSyntax", package: "SwiftSyntax"),
+                .product(name: "SwiftSyntaxParser", package: "SwiftSyntax"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
             ],
             path: "Sources/variable-injector/Core"),

--- a/Sources/variable-injector/Core/CommandLine/Tool.swift
+++ b/Sources/variable-injector/Core/CommandLine/Tool.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftSyntax
+import SwiftSyntaxParser
 import ArgumentParser
 
 public struct VariableInjectorTool: ParsableCommand {

--- a/Tests/variable-injectorTests/VariableInjectorTests.swift
+++ b/Tests/variable-injectorTests/VariableInjectorTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import SwiftSyntax
+import SwiftSyntaxParser
 import variable_injector_core
 
 final class VariableInjectorTests: XCTestCase {


### PR DESCRIPTION
SwiftSyntax just released a fix to their 0.50600.0 build in 0.50600.1.  This updates the dependency so Variable Injector should be compatible with Swift 5.6 and Xcode 13.3

Should address #23 